### PR TITLE
Adds wheels for linux/aarch64

### DIFF
--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -20,17 +20,31 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-12, macos-14]
+        include:
+          - os: ubuntu-latest
+            arch: "x86_64 aarch64"
+          - os: windows-latest
+            arch: native
+          - os: macos-12
+            arch: native
+          - os: macos-14
+            arch: native
 
     steps:
       - uses: actions/checkout@v4
+
+      - name: Set up QEMU
+        if: matrix.os == 'ubuntu-latest'
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: all
 
       - name: Build wheels
         uses: pypa/cibuildwheel@v2.20.0
         env:
           # Select wheels
-          CIBW_BUILD: "cp311-manylinux_x86_64 cp311-win_amd64 cp311-macosx_x86_64 cp311-macosx_arm64"
-          CIBW_ARCHS: "native"
+          CIBW_BUILD: "cp311-manylinux_x86_64 cp311-manylinux_aarch64 cp311-win_amd64 cp311-macosx_x86_64 cp311-macosx_arm64"
+          CIBW_ARCHS: ${{ matrix.arch }}
           # use manylinux2014
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_LINUX: >

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -47,6 +47,7 @@ jobs:
           CIBW_ARCHS: ${{ matrix.arch }}
           # use manylinux2014
           CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
           CIBW_BEFORE_ALL_LINUX: >
             pip install patchelf
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""

--- a/.github/workflows/wheel.yml
+++ b/.github/workflows/wheel.yml
@@ -44,10 +44,10 @@ jobs:
         env:
           # Select wheels
           CIBW_BUILD: "cp311-manylinux_x86_64 cp311-manylinux_aarch64 cp311-win_amd64 cp311-macosx_x86_64 cp311-macosx_arm64"
-          CIBW_ARCHS: ${{ matrix.arch }}
+          CIBW_ARCHS: "${{ matrix.arch }}"
           # use manylinux2014
-          CIBW_MANYLINUX_X86_64_IMAGE: manylinux2014
-          CIBW_MANYLINUX_AARCH64_IMAGE: manylinux2014
+          CIBW_MANYLINUX_X86_64_IMAGE: "quay.io/pypa/manylinux2014_x86_64"
+          CIBW_MANYLINUX_AARCH64_IMAGE: "quay.io/pypa/manylinux2014_aarch64"
           CIBW_BEFORE_ALL_LINUX: >
             pip install patchelf
           CIBW_REPAIR_WHEEL_COMMAND_LINUX: ""

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This is the python wheel distribution for binaries of [HiGHS](https://github.com
 
 The current version is 1.7.2 built for the following platforms:
 - Windows (x86_64)
-- Linux (x86_64)
+- Linux (x86_64, aarch64)
 - MacOS (x86_64)
 - MacOS (arm64)
 

--- a/README.md
+++ b/README.md
@@ -6,7 +6,8 @@ This is the python wheel distribution for binaries of [HiGHS](https://github.com
 
 The current version is 1.7.2 built for the following platforms:
 - Windows (x86_64)
-- Linux (x86_64, aarch64)
+- Linux (x86_64)
+- Linux (aarch64)
 - MacOS (x86_64)
 - MacOS (arm64)
 

--- a/setup.py
+++ b/setup.py
@@ -13,9 +13,12 @@ class genericpy_bdist_wheel(_bdist_wheel):
     def get_tag(self):
         python, abi, plat = _bdist_wheel.get_tag(self)
         python, abi = "py3", "none"
-        if os.environ.get("CIBUILDWHEEL", "0") == "1" and plat == "linux_x86_64":
+        if os.environ.get("CIBUILDWHEEL", "0") == "1":
             # pypi does not allow linux_x86_64 wheels to be uploaded
-            plat = "manylinux2014_x86_64"
+            if plat == "linux_x86_64":
+                plat = "manylinux2014_x86_64"
+            elif plat == "linux_aarch64":
+                plat = "manylinux2014_aarch64"
         return python, abi, plat
 
 


### PR DESCRIPTION
# Description

This PR adds wheels for _linux-aarch64_.

## Changes

- Adds `cp311-manylinux_aarch64` wheels build target.
- Updated readme and tag override accordingly.

## Notes

- I did not move the build config from the workflow definition to the project file as I did for my PyOptInterface PR. Happy to also do that here as well, if you liked it. (see metab0t/PyOptInterface#23)